### PR TITLE
Make sure the browser thinks it's doing actual work.

### DIFF
--- a/workload.js
+++ b/workload.js
@@ -13,5 +13,6 @@ self.onmessage = function(event) {
 		d = (a ^ d) << 1;
 	}
 
+	// Pass information back to thwart optimizers.
 	postMessage(a);
 };

--- a/workload.js
+++ b/workload.js
@@ -13,5 +13,5 @@ self.onmessage = function(event) {
 		d = (a ^ d) << 1;
 	}
 
-	postMessage(null);
+	postMessage(a);
 };


### PR DESCRIPTION
An optimizing JavaScript engine could easily ascertain that the results of the calculations performed by the workers aren't used for anything and optimize them out, thus allowing the workers to finish immediately and rendering the results worthless. If the value of `a` is passed back to the main thread, it becomes much more difficult for the engine to determine how it's used, i.e. not at all.

Even if this hasn't been a problem yet, I'd say it's best not to rely on good luck. Plus, this version is three bytes shorter minified. 😏
